### PR TITLE
Fix extra attributes warning in app-index.tsx

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -20,7 +20,7 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en">
-      <body className={inter.className} suppressHydrationWarning>
+      <body className={inter.className}>
         <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
           <Provider store={store}>
             <div className="min-h-screen bg-background">


### PR DESCRIPTION
Fix the warning about extra attributes from the server (class, style) in `app-index.tsx:25`.

* Remove the `suppressHydrationWarning` attribute from the `body` element in `app/layout.tsx`.
* Ensure the `className` attribute is correctly applied to the `body` element in `app/layout.tsx`.

