### PR TITLE
Implement Prisma SQLite, Google, GitHub SSO, complete sign up and sign in

### DIFF
--- a/app/hooks/use-auth.ts
+++ b/app/hooks/use-auth.ts
@@ -1,7 +1,8 @@
-import { useAppSelector } from "../store/hooks"
+import { useSession } from "next-auth/react"
 
 export function useAuth() {
-  const currentUser = useAppSelector((state) => state.users.currentUser)
+  const { data: session } = useSession()
+  const currentUser = session?.user
 
   const isAdmin = currentUser?.role === "admin"
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -9,6 +9,7 @@ import { Breadcrumbs } from "./components/breadcrumbs"
 import "./globals.css"
 import {ThemeProvider} from "@/app/components/theme-provider";
 import React from "react";
+import { SessionProvider } from "next-auth/react";
 
 const inter = Inter({ subsets: ["latin"] })
 
@@ -22,16 +23,18 @@ export default function RootLayout({
     <html lang="en">
       <body className={inter.className}>
         <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
-          <Provider store={store}>
-            <div className="min-h-screen bg-background">
-              <NavBar />
-              <main className="container mx-auto py-4 px-4 sm:px-6 lg:px-8">
-                <Breadcrumbs />
-                {children}
-              </main>
-            </div>
-            <Toaster />
-          </Provider>
+          <SessionProvider>
+            <Provider store={store}>
+              <div className="min-h-screen bg-background">
+                <NavBar />
+                <main className="container mx-auto py-4 px-4 sm:px-6 lg:px-8">
+                  <Breadcrumbs />
+                  {children}
+                </main>
+              </div>
+              <Toaster />
+            </Provider>
+          </SessionProvider>
         </ThemeProvider>
       </body>
     </html>

--- a/app/store/usersSlice.ts
+++ b/app/store/usersSlice.ts
@@ -3,6 +3,7 @@
 import {createAsyncThunk, createSlice, type PayloadAction} from "@reduxjs/toolkit"
 import {getUser, getUsers, type User, type UserId} from "../lib/api"
 import {logError} from "../utils/errorLogging"
+import { signOut } from "next-auth/react"
 
 interface UsersState {
   users: User[]
@@ -41,6 +42,10 @@ export const addUser = createAsyncThunk("users/addUser", async (userData: Omit<U
   }
 })
 
+export const signOutUser = createAsyncThunk("users/signOutUser", async () => {
+  await signOut()
+})
+
 const usersSlice = createSlice({
   name: "users",
   initialState,
@@ -71,6 +76,9 @@ const usersSlice = createSlice({
       })
       .addCase(addUser.fulfilled, (state, action: PayloadAction<User>) => {
         state.users.push(action.payload)
+      })
+      .addCase(signOutUser.fulfilled, (state) => {
+        state.currentUser = null
       })
   },
 })

--- a/pages/api/auth/[...nextauth].ts
+++ b/pages/api/auth/[...nextauth].ts
@@ -1,0 +1,31 @@
+import NextAuth from "next-auth"
+import { PrismaAdapter } from "@next-auth/prisma-adapter"
+import { PrismaClient } from "@prisma/client"
+import GoogleProvider from "next-auth/providers/google"
+import GitHubProvider from "next-auth/providers/github"
+
+const prisma = new PrismaClient()
+
+export default NextAuth({
+  providers: [
+    GoogleProvider({
+      clientId: process.env.GOOGLE_CLIENT_ID,
+      clientSecret: process.env.GOOGLE_CLIENT_SECRET,
+    }),
+    GitHubProvider({
+      clientId: process.env.GITHUB_CLIENT_ID,
+      clientSecret: process.env.GITHUB_CLIENT_SECRET,
+    }),
+  ],
+  adapter: PrismaAdapter(prisma),
+  session: {
+    strategy: "jwt",
+  },
+  callbacks: {
+    async session({ session, token, user }) {
+      session.user.id = user.id
+      session.user.role = user.role
+      return session
+    },
+  },
+})

--- a/pages/auth/signin.tsx
+++ b/pages/auth/signin.tsx
@@ -1,0 +1,16 @@
+import { signIn } from "next-auth/react"
+import { Button } from "@/components/ui/button"
+
+const SignIn = () => {
+  return (
+    <div className="container mx-auto py-10">
+      <h1 className="text-4xl font-bold mb-5">Sign In</h1>
+      <div className="space-y-4">
+        <Button onClick={() => signIn("google")}>Sign in with Google</Button>
+        <Button onClick={() => signIn("github")}>Sign in with GitHub</Button>
+      </div>
+    </div>
+  )
+}
+
+export default SignIn

--- a/pages/auth/signup.tsx
+++ b/pages/auth/signup.tsx
@@ -1,0 +1,16 @@
+import { signIn } from "next-auth/react"
+import { Button } from "@/components/ui/button"
+
+const SignUp = () => {
+  return (
+    <div className="container mx-auto py-10">
+      <h1 className="text-4xl font-bold mb-5">Sign Up</h1>
+      <div className="space-y-4">
+        <Button onClick={() => signIn("google")}>Sign up with Google</Button>
+        <Button onClick={() => signIn("github")}>Sign up with GitHub</Button>
+      </div>
+    </div>
+  )
+}
+
+export default SignUp

--- a/prisma/.env
+++ b/prisma/.env
@@ -1,0 +1,5 @@
+DATABASE_URL="file:./dev.db"
+GOOGLE_CLIENT_ID="your-google-client-id"
+GOOGLE_CLIENT_SECRET="your-google-client-secret"
+GITHUB_CLIENT_ID="your-github-client-id"
+GITHUB_CLIENT_SECRET="your-github-client-secret"

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,0 +1,54 @@
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "sqlite"
+  url      = env("DATABASE_URL")
+}
+
+model User {
+  id        Int      @id @default(autoincrement())
+  name      String
+  email     String   @unique
+  role      String
+  createdAt DateTime @default(now())
+  accounts  Account[]
+  sessions  Session[]
+}
+
+model Account {
+  id                 Int      @id @default(autoincrement())
+  userId             Int
+  provider           String
+  providerAccountId  String
+  refreshToken       String?  @map("refresh_token")
+  accessToken        String?  @map("access_token")
+  expiresAt          Int?     @map("expires_at")
+  tokenType          String?  @map("token_type")
+  scope              String?
+  idToken            String?  @map("id_token")
+  sessionState       String?  @map("session_state")
+  createdAt          DateTime @default(now())
+  user               User     @relation(fields: [userId], references: [id])
+
+  @@unique([provider, providerAccountId])
+}
+
+model Session {
+  id           Int      @id @default(autoincrement())
+  userId       Int
+  sessionToken String   @unique
+  expires      DateTime
+  createdAt    DateTime @default(now())
+  user         User     @relation(fields: [userId], references: [id])
+}
+
+model VerificationToken {
+  identifier String
+  token      String   @unique
+  expires    DateTime
+  createdAt  DateTime @default(now())
+
+  @@unique([identifier, token])
+}


### PR DESCRIPTION
Implement Prisma ORM with SQLite database configuration and add Google and GitHub SSO using NextAuth.js.

* **Prisma and SQLite Configuration**
  - Add `prisma/schema.prisma` to define `User`, `Account`, `Session`, and `VerificationToken` models.
  - Add `prisma/.env` to configure `DATABASE_URL`, `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`, `GITHUB_CLIENT_ID`, and `GITHUB_CLIENT_SECRET`.

* **NextAuth.js Integration**
  - Add `pages/api/auth/[...nextauth].ts` to configure NextAuth with Google and GitHub providers and Prisma adapter.

* **Sign-In and Sign-Up Pages**
  - Add `pages/auth/signin.tsx` to create a sign-in page with Google and GitHub sign-in buttons.
  - Add `pages/auth/signup.tsx` to create a sign-up page with Google and GitHub sign-up buttons.

* **Authentication Context**
  - Modify `app/layout.tsx` to wrap the `Provider` component with `SessionProvider` from NextAuth.

* **User Authentication and Authorization Logic**
  - Modify `app/hooks/use-auth.ts` to use `useSession` from NextAuth for current user session.
  - Modify `app/store/usersSlice.ts` to add `signOutUser` async thunk and handle user sign-out.

